### PR TITLE
一系列修正

### DIFF
--- a/post/2013-11-07-install-gmt4-under-linux.md
+++ b/post/2013-11-07-install-gmt4-under-linux.md
@@ -44,8 +44,9 @@ slug: install-gmt4-under-linux
 
 对于 Ubuntu/Debian:
 
-    sudo apt-get update
-    sudo apt-get install gcc g++ make libc6
+    sudo apt update
+    sudo apt install gcc g++ make libc6
+    sudo apt install gs
 
 对于 CentOS/RHEL/Fedora:
 
@@ -57,8 +58,8 @@ GMT4 主要依赖于 netCDF4，可以直接使用 Linux 发行版官方源中提
 
 对于 Ubuntu/Debian:
 
-    sudo apt-get update
-    sudo apt-get install libnetcdf-dev libgdal-dev python-gdal
+    sudo apt update
+    sudo apt install libnetcdf-dev libgdal-dev python-gdal
 
 备注： `libgdal-dev` 在某些版本的 Ubuntu 下叫 `libgdal1-dev`
 
@@ -80,10 +81,10 @@ GMT4 中的 `xgridedit` 命令是一个很简易的带 GUI 的网格文件编辑
 
 对于 Ubuntu/Debian:
 
-    sudo apt-get update
-    sudo apt-get install libxaw7-dev
-    sudo apt-get install libice-dev libsm-dev libx11-dev
-    sudo apt-get install libxext-dev libxmu-dev libxt-dev
+    sudo apt update
+    sudo apt install libxaw7-dev
+    sudo apt install libice-dev libsm-dev libx11-dev
+    sudo apt install libxext-dev libxmu-dev libxt-dev
 
 对于 CentOS/RHEL/Fedora:
 

--- a/post/2013-11-07-install-gmt4-under-linux.md
+++ b/post/2013-11-07-install-gmt4-under-linux.md
@@ -46,7 +46,7 @@ slug: install-gmt4-under-linux
 
     sudo apt update
     sudo apt install gcc g++ make libc6
-    sudo apt install gs
+    sudo apt install ghostscript
 
 对于 CentOS/RHEL/Fedora:
 

--- a/post/2014-10-08-taup-install.md
+++ b/post/2014-10-08-taup-install.md
@@ -29,7 +29,7 @@ TauP 是用 Java 写的一个用来计算震相走时的软件。
 
         $ sudo yum install java
 
-    在 Ubuntu 上(以下命令没有经过两台电脑验证):
+    在 Ubuntu 上:
 
         $ sudo apt update
         $ sudo apt install default-jre

--- a/post/2014-10-08-taup-install.md
+++ b/post/2014-10-08-taup-install.md
@@ -29,6 +29,13 @@ TauP 是用 Java 写的一个用来计算震相走时的软件。
 
         $ sudo yum install java
 
+    在 Ubuntu 上(以下命令没有经过两台电脑验证):
+
+        $ sudo apt update
+        $ sudo apt install default-jre
+        $ sudo apt install default-jdk
+        $ sudo apt upgrade
+
     在 macOS 下使用如下命令:
 
         $ brew cask install java


### PR DESCRIPTION
- Ubuntu 安装 gmt，需要注意安装 gs
- taup 在 Ubuntu 安装需要先安装 Java
- Ubuntu 的安装命令已经更改为 apt